### PR TITLE
input-leap 3.0.2 (new cask)

### DIFF
--- a/Casks/i/input-leap.rb
+++ b/Casks/i/input-leap.rb
@@ -1,0 +1,18 @@
+cask "input-leap" do
+  version "3.0.2"
+  sha256 "e7a27f187e4e97f724e7b0ae9f9490be27d3e81a6cac0e3cf85654b37f28b1a3"
+
+  url "https://github.com/input-leap/input-leap/releases/download/v#{version}/InputLeap_#{version}_macos_AppleSilicon.dmg"
+  name "Input Leap"
+  desc "Open-source KVM software"
+  homepage "https://github.com/input-leap/input-leap"
+
+  depends_on macos: ">= :catalina"
+
+  app "InputLeap.app"
+
+  zap trash: [
+    "~/Library/Application Support/InputLeap",
+    "~/Library/Saved Application State/InputLeap.savedState",
+  ]
+end


### PR DESCRIPTION
Adds [input-leap](https://github.com/input-leap/input-leap) 3.0.2 an open-source KVM fork of [barrier](https://github.com/debauchee/barrier/releases).

*Rejected by Homebrew in https://github.com/Homebrew/homebrew-cask/pull/211962*